### PR TITLE
Features: Ubuntu 24.04, PS 7.6, ORAS 1.3.1 checksum verified

### DIFF
--- a/images/hull-integration/Dockerfile
+++ b/images/hull-integration/Dockerfile
@@ -1,16 +1,37 @@
-FROM mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04
+FROM ubuntu:24.04
+ARG PS_VERSION=7.6.0
+ENV ORAS_VERSION="1.3.1"
+# Keep EXACTLY the same Dockerfile and Dockerfile-noroot, except USER noroot (shared layers)!
+# ORAS release checksum sources (ORAS setup or Release information, Linux amd64):
+# Store here, don't read at build time!
+# https://github.com/oras-project/oras/releases/download/v<version>/oras_<version>_checksums.txt
+# https://github.com/oras-project/setup-oras/blob/main/src/lib/data/releases.json
+# https://api.github.com/repos/oras-project/oras/releases/tags/v<version> (large Release content JSON)
+ENV ORAS_CHECKSUM="d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
+# 1.3.0: ENV ORAS_CHECKSUM="6cdc692f929100feb08aa8de584d02f7bcc30ec7d88bc2adc2054d782db57c64"
 RUN apt-get update \
- && apt-get -y upgrade \
- && apt-get -y install curl \
+ && apt-get -y --no-install-recommends upgrade \
+ && apt-get -y install --no-install-recommends ca-certificates curl \
+ && echo "Setting variables from /etc/os-release..." \
+ && . /etc/os-release \
+ && echo "OS VERSION_ID: ${VERSION_ID}" \
+ && curl -fsSLO https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
+ && rm packages-microsoft-prod.deb \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends powershell \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
  && pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml \
- && rm -rf /var/lib/apt/lists/*
-ENV VERSION="1.3.0"
-RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" \
- && ls \
+ && echo "Downloading and installing ORAS CLI version ${ORAS_VERSION}..." \
+ && curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+ && echo "${ORAS_CHECKSUM}  oras_${ORAS_VERSION}_linux_amd64.tar.gz" | sha256sum -c - \
  && mkdir -p oras-install/ \
- && tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/ \
+ && tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/ \
  && mv oras-install/oras /usr/local/bin/ \
- && rm -rf oras_${VERSION}_*.tar.gz oras-install/ \
- && oras --help
-COPY ./Installer.ps1 /script/Installer.ps1
-COPY ./get-custom-scripts /get-custom-scripts
+ && rm -rf oras_${ORAS_VERSION}_*.tar.gz oras-install/ \
+ && oras --help \
+ && groupadd -g 1001 noroot \
+ && useradd --create-home --shell /bin/bash -u 1001 -g noroot noroot
+COPY --chown=noroot:noroot ./Installer.ps1 /script/Installer.ps1
+COPY --chown=noroot:noroot ./get-custom-scripts /get-custom-scripts

--- a/images/hull-integration/Dockerfile
+++ b/images/hull-integration/Dockerfile
@@ -1,15 +1,16 @@
 FROM mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04
-RUN pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml
-RUN apt-get update
-RUN apt-get -y upgrade
-RUN apt-get -y install curl
+RUN apt-get update \
+ && apt-get -y upgrade \
+ && apt-get -y install curl \
+ && pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml \
+ && rm -rf /var/lib/apt/lists/*
 ENV VERSION="1.3.0"
-RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" 
-RUN ls
-RUN mkdir -p oras-install/
-RUN tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
-RUN mv oras-install/oras /usr/local/bin/
-RUN rm -rf oras_${VERSION}_*.tar.gz oras-install/
+RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" \
+ && ls \
+ && mkdir -p oras-install/ \
+ && tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/ \
+ && mv oras-install/oras /usr/local/bin/ \
+ && rm -rf oras_${VERSION}_*.tar.gz oras-install/ \
+ && oras --help
 COPY ./Installer.ps1 /script/Installer.ps1
 COPY ./get-custom-scripts /get-custom-scripts
-RUN oras --help

--- a/images/hull-integration/Dockerfile-noroot
+++ b/images/hull-integration/Dockerfile-noroot
@@ -1,19 +1,38 @@
-FROM mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04
+FROM ubuntu:24.04
+ARG PS_VERSION=7.6.0
+ENV ORAS_VERSION="1.3.1"
+# Keep EXACTLY the same Dockerfile and Dockerfile-noroot, except USER noroot (shared layers)!
+# ORAS release checksum sources (ORAS setup or Release information, Linux amd64):
+# Store here, don't read at build time!
+# https://github.com/oras-project/oras/releases/download/v<version>/oras_<version>_checksums.txt
+# https://github.com/oras-project/setup-oras/blob/main/src/lib/data/releases.json
+# https://api.github.com/repos/oras-project/oras/releases/tags/v<version> (large Release content JSON)
+ENV ORAS_CHECKSUM="d52c4af76ce6a3ceb8579e51fb751a43ac051cca67f965f973a0b0e897a2bb86"
+# 1.3.0: ENV ORAS_CHECKSUM="6cdc692f929100feb08aa8de584d02f7bcc30ec7d88bc2adc2054d782db57c64"
 RUN apt-get update \
- && apt-get -y upgrade \
- && apt-get -y install curl \
+ && apt-get -y --no-install-recommends upgrade \
+ && apt-get -y install --no-install-recommends ca-certificates curl \
+ && echo "Setting variables from /etc/os-release..." \
+ && . /etc/os-release \
+ && echo "OS VERSION_ID: ${VERSION_ID}" \
+ && curl -fsSLO https://packages.microsoft.com/config/ubuntu/${VERSION_ID}/packages-microsoft-prod.deb \
+ && dpkg -i packages-microsoft-prod.deb \
+ && rm packages-microsoft-prod.deb \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends powershell \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
  && pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml \
- && rm -rf /var/lib/apt/lists/*
-ENV VERSION="1.3.0"
-RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" \
- && ls \
+ && echo "Downloading and installing ORAS CLI version ${ORAS_VERSION}..." \
+ && curl -LO "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz" \
+ && echo "${ORAS_CHECKSUM}  oras_${ORAS_VERSION}_linux_amd64.tar.gz" | sha256sum -c - \
  && mkdir -p oras-install/ \
- && tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/ \
+ && tar -zxf oras_${ORAS_VERSION}_*.tar.gz -C oras-install/ \
  && mv oras-install/oras /usr/local/bin/ \
- && rm -rf oras_${VERSION}_*.tar.gz oras-install/ \
- && oras --help
-# Create a user group 'noroot' and add a user noroot to group 'noroot'
-RUN groupadd noroot \
+ && rm -rf oras_${ORAS_VERSION}_*.tar.gz oras-install/ \
+ && oras --help \
+ && groupadd -g 1001 noroot \
  && useradd --create-home --shell /bin/bash -u 1001 -g noroot noroot
 COPY --chown=noroot:noroot ./Installer.ps1 /script/Installer.ps1
 COPY --chown=noroot:noroot ./get-custom-scripts /get-custom-scripts
+USER noroot

--- a/images/hull-integration/Dockerfile-noroot
+++ b/images/hull-integration/Dockerfile-noroot
@@ -1,21 +1,19 @@
 FROM mcr.microsoft.com/powershell:lts-7.4-ubuntu-22.04
-RUN pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml
-RUN apt-get update
-RUN apt-get -y upgrade
-RUN apt-get -y install curl
+RUN apt-get update \
+ && apt-get -y upgrade \
+ && apt-get -y install curl \
+ && pwsh -NonInteractive -Command Install-Module -Force -Scope AllUsers powershell-yaml \
+ && rm -rf /var/lib/apt/lists/*
 ENV VERSION="1.3.0"
-RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" 
-RUN ls
-RUN mkdir -p oras-install/
-RUN tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/
-RUN mv oras-install/oras /usr/local/bin/
-RUN rm -rf oras_${VERSION}_*.tar.gz oras-install/
-# Create a user group 'noroot'
-RUN groupadd noroot
-# Add a user noroot to group 'noroot'
-RUN useradd --create-home --shell /bin/bash -u 1001 -g noroot noroot
-COPY ./Installer.ps1 /script/Installer.ps1
-RUN chown -R noroot /script
-COPY ./get-custom-scripts /get-custom-scripts
-RUN chown -R noroot /get-custom-scripts
-RUN oras --help
+RUN curl -LO "https://github.com/oras-project/oras/releases/download/v${VERSION}/oras_${VERSION}_linux_amd64.tar.gz" \
+ && ls \
+ && mkdir -p oras-install/ \
+ && tar -zxf oras_${VERSION}_*.tar.gz -C oras-install/ \
+ && mv oras-install/oras /usr/local/bin/ \
+ && rm -rf oras_${VERSION}_*.tar.gz oras-install/ \
+ && oras --help
+# Create a user group 'noroot' and add a user noroot to group 'noroot'
+RUN groupadd noroot \
+ && useradd --create-home --shell /bin/bash -u 1001 -g noroot noroot
+COPY --chown=noroot:noroot ./Installer.ps1 /script/Installer.ps1
+COPY --chown=noroot:noroot ./get-custom-scripts /get-custom-scripts


### PR DESCRIPTION
Features: Ubuntu 24.04 base image instead of Microsoft PowerShell image, updated at build, PS 7.6 LTS, ORAS 1.3.1 checksum verified, ~500MB image size, smaller than before.

Important change; 
- The _hull-integration-noroot_ image now contains statement "_USER noroot_", starting containers as _noroot_ by default (before, only the user/group were created).
- The normal hull-integration image now contains a user noroot and switches the ownership of the script and directory to him (like  the -noroot image before), but it still starts as root by default.
- Fixed group ID 1001 for noroot group.